### PR TITLE
UUIDs Mapping

### DIFF
--- a/bundles/java/tools.vitruv.domains.java.echange/META-INF/MANIFEST.MF
+++ b/bundles/java/tools.vitruv.domains.java.echange/META-INF/MANIFEST.MF
@@ -20,5 +20,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.xtext.xbase.lib,
  tools.vitruv.framework.change.echange;visibility:=reexport,
+ tools.vitruv.framework.change.uuid;visibility:=reexport,
  tools.vitruv.domains.java.echange;visibility:=reexport
 Bundle-ActivationPolicy: lazy

--- a/bundles/java/tools.vitruv.domains.java.echange/metamodel/JavaEChange.genmodel
+++ b/bundles/java/tools.vitruv.domains.java.echange/metamodel/JavaEChange.genmodel
@@ -1,28 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
-    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/tools.vitruv.domains.java.echange/src-gen" editDirectory=""
-    editorDirectory="" modelPluginID="tools.vitruv.domains.java.echange" modelName="Change"
-    rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container" testsDirectory=""
-    importerID="org.eclipse.emf.ecore.xcore.importer" containmentProxies="true" complianceLevel="8.0"
-    copyrightFields="false" usedGenPackages="../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//attribute ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//feature ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//echange ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//list ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//single ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//reference ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//eobject ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//echange ../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//feature"
+    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/tools.vitruv.domains.java.echange/src-gen" modelPluginID="tools.vitruv.domains.java.echange"
+    modelName="Change" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false"
+    usedGenPackages="../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//attribute ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//feature ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//echange ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//list ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//single ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//reference ../../tools.vitruv.framework.change.echange/metamodel/echange.genmodel#//eobject ../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../tools.vitruv.framework.change.uuid/model/Uuid.genmodel#//uuid"
     operationReflection="true" importOrganizing="true">
-  <genAnnotations source="http://www.eclipse.org/emf/2002/GenModel/exporter/org.eclipse.xsd.ecore.exporter">
-    <genAnnotations source="selectedPackages">
-      <details key="http://www.eclipse.org/emf/2002/Ecore" value="Ecore.xsd"/>
-    </genAnnotations>
-    <details key="directoryURI" value="."/>
-  </genAnnotations>
-  <genAnnotations source="http://www.eclipse.org/emf/2002/GenModel/exporter/org.eclipse.xsd.ecore.exporter.xmi">
-    <genAnnotations source="selectedPackages">
-      <details key="http://www.eclipse.org/emf/2002/Ecore" value="EcoreXMI.xsd"/>
-    </genAnnotations>
-    <details key="directoryURI" value="."/>
-  </genAnnotations>
-  <foreignModel>Attribute.xcore</foreignModel>
-  <foreignModel>JavaFeature.xcore</foreignModel>
-  <foreignModel>Reference.xcore</foreignModel>
-  <modelPluginVariables>org.eclipse.xtext.xbase.lib</modelPluginVariables>
-  <modelPluginVariables>org.eclipse.emf.ecore.xcore.lib</modelPluginVariables>
+  <foreignModel>attribute.ecore</foreignModel>
+  <foreignModel>feature.ecore</foreignModel>
+  <foreignModel>reference.ecore</foreignModel>
   <genPackages prefix="Attribute" basePackage="tools.vitruv.domains.java.echange.feature"
       disposableProviderFactory="true" ecorePackage="attribute.ecore#/">
     <genClasses ecoreClass="attribute.ecore#//JavaInsertEAttributeValue">

--- a/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/FeaturePackage.java
+++ b/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/FeaturePackage.java
@@ -85,6 +85,15 @@ public interface FeaturePackage extends EPackage {
 	int JAVA_FEATURE_ECHANGE__AFFECTED_EOBJECT = tools.vitruv.framework.change.echange.feature.FeaturePackage.FEATURE_ECHANGE__AFFECTED_EOBJECT;
 
 	/**
+	 * The feature id for the '<em><b>Affected EObject ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_FEATURE_ECHANGE__AFFECTED_EOBJECT_ID = tools.vitruv.framework.change.echange.feature.FeaturePackage.FEATURE_ECHANGE__AFFECTED_EOBJECT_ID;
+
+	/**
 	 * The feature id for the '<em><b>Old Affected EObject</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -101,60 +110,6 @@ public interface FeaturePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_FEATURE_ECHANGE_FEATURE_COUNT = tools.vitruv.framework.change.echange.feature.FeaturePackage.FEATURE_ECHANGE_FEATURE_COUNT + 1;
-
-	/**
-	 * The operation id for the '<em>Resolve Before</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_FEATURE_ECHANGE___RESOLVE_BEFORE__RESOURCESET = tools.vitruv.framework.change.echange.feature.FeaturePackage.FEATURE_ECHANGE___RESOLVE_BEFORE__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_FEATURE_ECHANGE___RESOLVE_AFTER__RESOURCESET = tools.vitruv.framework.change.echange.feature.FeaturePackage.FEATURE_ECHANGE___RESOLVE_AFTER__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve Before And Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_FEATURE_ECHANGE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.FeaturePackage.FEATURE_ECHANGE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After And Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_FEATURE_ECHANGE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.FeaturePackage.FEATURE_ECHANGE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_FEATURE_ECHANGE___APPLY_FORWARD = tools.vitruv.framework.change.echange.feature.FeaturePackage.FEATURE_ECHANGE___APPLY_FORWARD;
-
-	/**
-	 * The operation id for the '<em>Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_FEATURE_ECHANGE___APPLY_BACKWARD = tools.vitruv.framework.change.echange.feature.FeaturePackage.FEATURE_ECHANGE___APPLY_BACKWARD;
 
 	/**
 	 * The operation id for the '<em>Is Resolved</em>' operation.

--- a/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/attribute/AttributePackage.java
+++ b/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/attribute/AttributePackage.java
@@ -84,6 +84,15 @@ public interface AttributePackage extends EPackage {
 	int JAVA_INSERT_EATTRIBUTE_VALUE__AFFECTED_EOBJECT = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.INSERT_EATTRIBUTE_VALUE__AFFECTED_EOBJECT;
 
 	/**
+	 * The feature id for the '<em><b>Affected EObject ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_INSERT_EATTRIBUTE_VALUE__AFFECTED_EOBJECT_ID = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.INSERT_EATTRIBUTE_VALUE__AFFECTED_EOBJECT_ID;
+
+	/**
 	 * The feature id for the '<em><b>Index</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -118,60 +127,6 @@ public interface AttributePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_INSERT_EATTRIBUTE_VALUE_FEATURE_COUNT = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.INSERT_EATTRIBUTE_VALUE_FEATURE_COUNT + 1;
-
-	/**
-	 * The operation id for the '<em>Resolve Before</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EATTRIBUTE_VALUE___RESOLVE_BEFORE__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.INSERT_EATTRIBUTE_VALUE___RESOLVE_BEFORE__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EATTRIBUTE_VALUE___RESOLVE_AFTER__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.INSERT_EATTRIBUTE_VALUE___RESOLVE_AFTER__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve Before And Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EATTRIBUTE_VALUE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.INSERT_EATTRIBUTE_VALUE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After And Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EATTRIBUTE_VALUE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.INSERT_EATTRIBUTE_VALUE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EATTRIBUTE_VALUE___APPLY_FORWARD = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.INSERT_EATTRIBUTE_VALUE___APPLY_FORWARD;
-
-	/**
-	 * The operation id for the '<em>Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EATTRIBUTE_VALUE___APPLY_BACKWARD = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.INSERT_EATTRIBUTE_VALUE___APPLY_BACKWARD;
 
 	/**
 	 * The operation id for the '<em>Is Resolved</em>' operation.
@@ -229,6 +184,15 @@ public interface AttributePackage extends EPackage {
 	int JAVA_REMOVE_EATTRIBUTE_VALUE__AFFECTED_EOBJECT = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REMOVE_EATTRIBUTE_VALUE__AFFECTED_EOBJECT;
 
 	/**
+	 * The feature id for the '<em><b>Affected EObject ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_REMOVE_EATTRIBUTE_VALUE__AFFECTED_EOBJECT_ID = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REMOVE_EATTRIBUTE_VALUE__AFFECTED_EOBJECT_ID;
+
+	/**
 	 * The feature id for the '<em><b>Index</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -263,60 +227,6 @@ public interface AttributePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_REMOVE_EATTRIBUTE_VALUE_FEATURE_COUNT = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REMOVE_EATTRIBUTE_VALUE_FEATURE_COUNT + 1;
-
-	/**
-	 * The operation id for the '<em>Resolve Before</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EATTRIBUTE_VALUE___RESOLVE_BEFORE__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REMOVE_EATTRIBUTE_VALUE___RESOLVE_BEFORE__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EATTRIBUTE_VALUE___RESOLVE_AFTER__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REMOVE_EATTRIBUTE_VALUE___RESOLVE_AFTER__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve Before And Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EATTRIBUTE_VALUE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REMOVE_EATTRIBUTE_VALUE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After And Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EATTRIBUTE_VALUE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REMOVE_EATTRIBUTE_VALUE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EATTRIBUTE_VALUE___APPLY_FORWARD = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REMOVE_EATTRIBUTE_VALUE___APPLY_FORWARD;
-
-	/**
-	 * The operation id for the '<em>Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EATTRIBUTE_VALUE___APPLY_BACKWARD = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REMOVE_EATTRIBUTE_VALUE___APPLY_BACKWARD;
 
 	/**
 	 * The operation id for the '<em>Is Resolved</em>' operation.
@@ -374,6 +284,15 @@ public interface AttributePackage extends EPackage {
 	int JAVA_REPLACE_SINGLE_VALUED_EATTRIBUTE__AFFECTED_EOBJECT = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REPLACE_SINGLE_VALUED_EATTRIBUTE__AFFECTED_EOBJECT;
 
 	/**
+	 * The feature id for the '<em><b>Affected EObject ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_REPLACE_SINGLE_VALUED_EATTRIBUTE__AFFECTED_EOBJECT_ID = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REPLACE_SINGLE_VALUED_EATTRIBUTE__AFFECTED_EOBJECT_ID;
+
+	/**
 	 * The feature id for the '<em><b>New Value</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -408,60 +327,6 @@ public interface AttributePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_REPLACE_SINGLE_VALUED_EATTRIBUTE_FEATURE_COUNT = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REPLACE_SINGLE_VALUED_EATTRIBUTE_FEATURE_COUNT + 1;
-
-	/**
-	 * The operation id for the '<em>Resolve Before</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EATTRIBUTE___RESOLVE_BEFORE__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REPLACE_SINGLE_VALUED_EATTRIBUTE___RESOLVE_BEFORE__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EATTRIBUTE___RESOLVE_AFTER__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REPLACE_SINGLE_VALUED_EATTRIBUTE___RESOLVE_AFTER__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve Before And Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EATTRIBUTE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REPLACE_SINGLE_VALUED_EATTRIBUTE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After And Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EATTRIBUTE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REPLACE_SINGLE_VALUED_EATTRIBUTE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EATTRIBUTE___APPLY_FORWARD = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REPLACE_SINGLE_VALUED_EATTRIBUTE___APPLY_FORWARD;
-
-	/**
-	 * The operation id for the '<em>Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EATTRIBUTE___APPLY_BACKWARD = tools.vitruv.framework.change.echange.feature.attribute.AttributePackage.REPLACE_SINGLE_VALUED_EATTRIBUTE___APPLY_BACKWARD;
 
 	/**
 	 * The operation id for the '<em>Is Resolved</em>' operation.

--- a/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/attribute/impl/AttributePackageImpl.java
+++ b/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/attribute/impl/AttributePackageImpl.java
@@ -31,6 +31,7 @@ import tools.vitruv.framework.change.echange.feature.list.ListPackage;
 import tools.vitruv.framework.change.echange.feature.reference.ReferencePackage;
 
 import tools.vitruv.framework.change.echange.feature.single.SinglePackage;
+import tools.vitruv.framework.change.uuid.UuidPackage;
 
 /**
  * <!-- begin-user-doc -->
@@ -114,8 +115,8 @@ public class AttributePackageImpl extends EPackageImpl implements AttributePacka
 		SinglePackage.eINSTANCE.eClass();
 		ReferencePackage.eINSTANCE.eClass();
 		EobjectPackage.eINSTANCE.eClass();
-		EChangePackage.eINSTANCE.eClass();
-		FeaturePackage.eINSTANCE.eClass();
+		EcorePackage.eINSTANCE.eClass();
+		UuidPackage.eINSTANCE.eClass();
 
 		// Obtain or create and register interdependencies
 		FeaturePackageImpl theFeaturePackage_1 = (FeaturePackageImpl)(EPackage.Registry.INSTANCE.getEPackage(tools.vitruv.domains.java.echange.feature.FeaturePackage.eNS_URI) instanceof FeaturePackageImpl ? EPackage.Registry.INSTANCE.getEPackage(tools.vitruv.domains.java.echange.feature.FeaturePackage.eNS_URI) : tools.vitruv.domains.java.echange.feature.FeaturePackage.eINSTANCE);

--- a/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/impl/FeaturePackageImpl.java
+++ b/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/impl/FeaturePackageImpl.java
@@ -30,6 +30,7 @@ import tools.vitruv.framework.change.echange.feature.list.ListPackage;
 import tools.vitruv.framework.change.echange.feature.reference.ReferencePackage;
 
 import tools.vitruv.framework.change.echange.feature.single.SinglePackage;
+import tools.vitruv.framework.change.uuid.UuidPackage;
 
 /**
  * <!-- begin-user-doc -->
@@ -99,8 +100,8 @@ public class FeaturePackageImpl extends EPackageImpl implements FeaturePackage {
 		SinglePackage.eINSTANCE.eClass();
 		ReferencePackage.eINSTANCE.eClass();
 		EobjectPackage.eINSTANCE.eClass();
-		EChangePackage.eINSTANCE.eClass();
-		tools.vitruv.framework.change.echange.feature.FeaturePackage.eINSTANCE.eClass();
+		EcorePackage.eINSTANCE.eClass();
+		UuidPackage.eINSTANCE.eClass();
 
 		// Obtain or create and register interdependencies
 		AttributePackageImpl theAttributePackage_1 = (AttributePackageImpl)(EPackage.Registry.INSTANCE.getEPackage(tools.vitruv.domains.java.echange.feature.attribute.AttributePackage.eNS_URI) instanceof AttributePackageImpl ? EPackage.Registry.INSTANCE.getEPackage(tools.vitruv.domains.java.echange.feature.attribute.AttributePackage.eNS_URI) : tools.vitruv.domains.java.echange.feature.attribute.AttributePackage.eINSTANCE);

--- a/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/impl/JavaFeatureEChangeImpl.java
+++ b/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/impl/JavaFeatureEChangeImpl.java
@@ -62,17 +62,6 @@ public abstract class JavaFeatureEChangeImpl<A extends EObject, F extends EStruc
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * This is specialized for the more specific type known in this context.
-	 * @generated
-	 */
-	@Override
-	public void setAffectedFeature(F newAffectedFeature) {
-		super.setAffectedFeature(newAffectedFeature);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")

--- a/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/reference/ReferencePackage.java
+++ b/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/reference/ReferencePackage.java
@@ -84,6 +84,15 @@ public interface ReferencePackage extends EPackage {
 	int JAVA_INSERT_EREFERENCE__AFFECTED_EOBJECT = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE__AFFECTED_EOBJECT;
 
 	/**
+	 * The feature id for the '<em><b>Affected EObject ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_INSERT_EREFERENCE__AFFECTED_EOBJECT_ID = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE__AFFECTED_EOBJECT_ID;
+
+	/**
 	 * The feature id for the '<em><b>Index</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -100,6 +109,15 @@ public interface ReferencePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_INSERT_EREFERENCE__NEW_VALUE = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE__NEW_VALUE;
+
+	/**
+	 * The feature id for the '<em><b>New Value ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_INSERT_EREFERENCE__NEW_VALUE_ID = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE__NEW_VALUE_ID;
 
 	/**
 	 * The feature id for the '<em><b>Old Affected EObject</b></em>' reference.
@@ -120,58 +138,13 @@ public interface ReferencePackage extends EPackage {
 	int JAVA_INSERT_EREFERENCE_FEATURE_COUNT = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE_FEATURE_COUNT + 1;
 
 	/**
-	 * The operation id for the '<em>Resolve Before</em>' operation.
+	 * The operation id for the '<em>Is Resolved</em>' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int JAVA_INSERT_EREFERENCE___RESOLVE_BEFORE__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE___RESOLVE_BEFORE__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EREFERENCE___RESOLVE_AFTER__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE___RESOLVE_AFTER__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve Before And Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EREFERENCE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After And Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EREFERENCE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EREFERENCE___APPLY_FORWARD = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE___APPLY_FORWARD;
-
-	/**
-	 * The operation id for the '<em>Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EREFERENCE___APPLY_BACKWARD = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE___APPLY_BACKWARD;
+	int JAVA_INSERT_EREFERENCE___IS_RESOLVED = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE___IS_RESOLVED;
 
 	/**
 	 * The operation id for the '<em>Get New Value</em>' operation.
@@ -190,15 +163,6 @@ public interface ReferencePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_INSERT_EREFERENCE___IS_CONTAINMENT = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE___IS_CONTAINMENT;
-
-	/**
-	 * The operation id for the '<em>Is Resolved</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_INSERT_EREFERENCE___IS_RESOLVED = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.INSERT_EREFERENCE___IS_RESOLVED;
 
 	/**
 	 * The number of operations of the '<em>Java Insert EReference</em>' class.
@@ -238,6 +202,15 @@ public interface ReferencePackage extends EPackage {
 	int JAVA_REMOVE_EREFERENCE__AFFECTED_EOBJECT = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE__AFFECTED_EOBJECT;
 
 	/**
+	 * The feature id for the '<em><b>Affected EObject ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_REMOVE_EREFERENCE__AFFECTED_EOBJECT_ID = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE__AFFECTED_EOBJECT_ID;
+
+	/**
 	 * The feature id for the '<em><b>Index</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -254,6 +227,15 @@ public interface ReferencePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_REMOVE_EREFERENCE__OLD_VALUE = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE__OLD_VALUE;
+
+	/**
+	 * The feature id for the '<em><b>Old Value ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_REMOVE_EREFERENCE__OLD_VALUE_ID = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE__OLD_VALUE_ID;
 
 	/**
 	 * The feature id for the '<em><b>Old Affected EObject</b></em>' reference.
@@ -274,58 +256,13 @@ public interface ReferencePackage extends EPackage {
 	int JAVA_REMOVE_EREFERENCE_FEATURE_COUNT = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE_FEATURE_COUNT + 1;
 
 	/**
-	 * The operation id for the '<em>Resolve Before</em>' operation.
+	 * The operation id for the '<em>Is Resolved</em>' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int JAVA_REMOVE_EREFERENCE___RESOLVE_BEFORE__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE___RESOLVE_BEFORE__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EREFERENCE___RESOLVE_AFTER__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE___RESOLVE_AFTER__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve Before And Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EREFERENCE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After And Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EREFERENCE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EREFERENCE___APPLY_FORWARD = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE___APPLY_FORWARD;
-
-	/**
-	 * The operation id for the '<em>Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EREFERENCE___APPLY_BACKWARD = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE___APPLY_BACKWARD;
+	int JAVA_REMOVE_EREFERENCE___IS_RESOLVED = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE___IS_RESOLVED;
 
 	/**
 	 * The operation id for the '<em>Get Old Value</em>' operation.
@@ -344,15 +281,6 @@ public interface ReferencePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_REMOVE_EREFERENCE___IS_CONTAINMENT = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE___IS_CONTAINMENT;
-
-	/**
-	 * The operation id for the '<em>Is Resolved</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REMOVE_EREFERENCE___IS_RESOLVED = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REMOVE_EREFERENCE___IS_RESOLVED;
 
 	/**
 	 * The number of operations of the '<em>Java Remove EReference</em>' class.
@@ -392,6 +320,15 @@ public interface ReferencePackage extends EPackage {
 	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE__AFFECTED_EOBJECT = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE__AFFECTED_EOBJECT;
 
 	/**
+	 * The feature id for the '<em><b>Affected EObject ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE__AFFECTED_EOBJECT_ID = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE__AFFECTED_EOBJECT_ID;
+
+	/**
 	 * The feature id for the '<em><b>New Value</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -401,6 +338,15 @@ public interface ReferencePackage extends EPackage {
 	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE__NEW_VALUE = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE__NEW_VALUE;
 
 	/**
+	 * The feature id for the '<em><b>New Value ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE__NEW_VALUE_ID = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE__NEW_VALUE_ID;
+
+	/**
 	 * The feature id for the '<em><b>Old Value</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -408,6 +354,15 @@ public interface ReferencePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE__OLD_VALUE = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE__OLD_VALUE;
+
+	/**
+	 * The feature id for the '<em><b>Old Value ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE__OLD_VALUE_ID = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE__OLD_VALUE_ID;
 
 	/**
 	 * The feature id for the '<em><b>Old Affected EObject</b></em>' reference.
@@ -428,58 +383,13 @@ public interface ReferencePackage extends EPackage {
 	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE_FEATURE_COUNT = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE_FEATURE_COUNT + 1;
 
 	/**
-	 * The operation id for the '<em>Resolve Before</em>' operation.
+	 * The operation id for the '<em>Is Resolved</em>' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE___RESOLVE_BEFORE__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE___RESOLVE_BEFORE__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE___RESOLVE_AFTER__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE___RESOLVE_AFTER__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve Before And Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE___RESOLVE_BEFORE_AND_APPLY_FORWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Resolve After And Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE___RESOLVE_AFTER_AND_APPLY_BACKWARD__RESOURCESET;
-
-	/**
-	 * The operation id for the '<em>Apply Forward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE___APPLY_FORWARD = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE___APPLY_FORWARD;
-
-	/**
-	 * The operation id for the '<em>Apply Backward</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE___APPLY_BACKWARD = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE___APPLY_BACKWARD;
+	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE___IS_RESOLVED = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE___IS_RESOLVED;
 
 	/**
 	 * The operation id for the '<em>Get New Value</em>' operation.
@@ -525,15 +435,6 @@ public interface ReferencePackage extends EPackage {
 	 * @ordered
 	 */
 	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE___IS_CONTAINMENT = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE___IS_CONTAINMENT;
-
-	/**
-	 * The operation id for the '<em>Is Resolved</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int JAVA_REPLACE_SINGLE_VALUED_EREFERENCE___IS_RESOLVED = tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.REPLACE_SINGLE_VALUED_EREFERENCE___IS_RESOLVED;
 
 	/**
 	 * The number of operations of the '<em>Java Replace Single Valued EReference</em>' class.

--- a/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/reference/impl/ReferencePackageImpl.java
+++ b/bundles/java/tools.vitruv.domains.java.echange/src-gen/tools/vitruv/domains/java/echange/feature/reference/impl/ReferencePackageImpl.java
@@ -31,6 +31,7 @@ import tools.vitruv.framework.change.echange.feature.attribute.AttributePackage;
 import tools.vitruv.framework.change.echange.feature.list.ListPackage;
 
 import tools.vitruv.framework.change.echange.feature.single.SinglePackage;
+import tools.vitruv.framework.change.uuid.UuidPackage;
 
 /**
  * <!-- begin-user-doc -->
@@ -114,8 +115,8 @@ public class ReferencePackageImpl extends EPackageImpl implements ReferencePacka
 		SinglePackage.eINSTANCE.eClass();
 		tools.vitruv.framework.change.echange.feature.reference.ReferencePackage.eINSTANCE.eClass();
 		EobjectPackage.eINSTANCE.eClass();
-		EChangePackage.eINSTANCE.eClass();
-		FeaturePackage.eINSTANCE.eClass();
+		EcorePackage.eINSTANCE.eClass();
+		UuidPackage.eINSTANCE.eClass();
 
 		// Obtain or create and register interdependencies
 		AttributePackageImpl theAttributePackage_1 = (AttributePackageImpl)(EPackage.Registry.INSTANCE.getEPackage(tools.vitruv.domains.java.echange.feature.attribute.AttributePackage.eNS_URI) instanceof AttributePackageImpl ? EPackage.Registry.INSTANCE.getEPackage(tools.vitruv.domains.java.echange.feature.attribute.AttributePackage.eNS_URI) : tools.vitruv.domains.java.echange.feature.attribute.AttributePackage.eINSTANCE);

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor/src/tools/vitruv/domains/java/monitorededitor/MonitoredEditor.java
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor/src/tools/vitruv/domains/java/monitorededitor/MonitoredEditor.java
@@ -20,6 +20,7 @@ import tools.vitruv.domains.java.monitorededitor.refactoringlistener.Refactoring
 import tools.vitruv.framework.change.description.CompositeContainerChange;
 import tools.vitruv.framework.change.description.PropagatedChange;
 import tools.vitruv.framework.change.description.VitruviusChangeFactory;
+import tools.vitruv.framework.change.uuid.UuidGeneratorAndResolver;
 import tools.vitruv.framework.change.description.VitruviusChange;
 import tools.vitruv.framework.monitorededitor.AbstractMonitoredEditor;
 import tools.vitruv.framework.userinteraction.UserInteracting;
@@ -124,6 +125,10 @@ public class MonitoredEditor extends AbstractMonitoredEditor
 			}
 			@Override
 			public void reverseChanges(List<PropagatedChange> changes) {
+			}
+			@Override
+			public UuidGeneratorAndResolver getUuidGeneratorAndResolver() {
+				return null;
 			}
         }, MY_MONITORED_PROJECT);
         this.reportChanges = true;

--- a/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/tuid/JavaTuidCalculatorAndResolver.xtend
+++ b/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/tuid/JavaTuidCalculatorAndResolver.xtend
@@ -53,6 +53,7 @@ class JavaTuidCalculatorAndResolver extends HierarchicalTuidCalculatorAndResolve
 
 	private val static Logger logger = Logger.getLogger(JavaTuidCalculatorAndResolver);
 
+	private val String PARAMETER_SELECTOR = "parameter"
 	private val String CLASSIFIER_SELECTOR = "classifier"
 	private val String IMPORT_SELECTOR = "import"
 	private val String METHOD_SELECTOR = "method"
@@ -146,7 +147,7 @@ class JavaTuidCalculatorAndResolver extends HierarchicalTuidCalculatorAndResolve
 	}
 
 	private def dispatch String calculateIndividualTuid(Parameter param) {
-		return param.name
+		return PARAMETER_SELECTOR + SUBDIVIDER + param.name
 	}
 
 	private def dispatch String calculateIndividualTuid(NamespaceClassifierReference ref) {
@@ -156,7 +157,7 @@ class JavaTuidCalculatorAndResolver extends HierarchicalTuidCalculatorAndResolve
 		if (ref.eContainingFeature !== null) {
 			tuid.append(ref.eContainingFeature.name)
 		}
-		ref.classifierReferences.forEach[tuid.append(target.name)]
+		ref.classifierReferences.forEach[tuid.append(target?.name)]
 		return tuid.toString
 	}
 
@@ -322,8 +323,8 @@ class JavaTuidCalculatorAndResolver extends HierarchicalTuidCalculatorAndResolve
 
 	private def dispatch String calculateIndividualTuid(ClassifierReference classifierReference) {
 		val tuid = new StringBuilder()
-		tuid.append(classifierReference.eContainingFeature.name)
-		tuid.append(classifierReference.target.name)
+		tuid.append(classifierReference.eContainingFeature?.name)
+		tuid.append(classifierReference.target?.name)
 		return tuid.toString
 	}
 
@@ -352,7 +353,7 @@ class JavaTuidCalculatorAndResolver extends HierarchicalTuidCalculatorAndResolve
 	}
 
 	private def dispatch String getNameFrom(ClassifierReference classifierReference) {
-		return classifierReference.target.name
+		return classifierReference.target?.name
 	}
 	
 	private def dispatch String getNameFrom(Void nullType){


### PR DESCRIPTION
This PR adapts the Domains to the introduction of UUIDs in the Vitruv framework.
It especially adapts the Java-specific change descriptions metamodel.
Additionally, it extends the `JavaTuidCalculatorAndResolver` to correctly handle the cases introduced by completely unresolving and reapplying changes.