### PR TITLE
Allow transitive change propagation

### DIFF
--- a/bundles/emfprofiles/tools.vitruv.domains.emfprofiles/build.properties
+++ b/bundles/emfprofiles/tools.vitruv.domains.emfprofiles/build.properties
@@ -1,5 +1,6 @@
 source.. = src/,\
-           xtend-gen/
+           xtend-gen/,\
+           src-test/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\

--- a/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JavaDomain.xtend
+++ b/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JavaDomain.xtend
@@ -8,7 +8,8 @@ import org.emftext.language.java.JavaClasspath
 
 final class JavaDomain extends AbstractVitruvDomain {
 	private static final String METAMODEL_NAME = "Java";
-	
+	private boolean shouldTransitivelyPropagateChanges = false;
+		
 	package new() {
 		super(METAMODEL_NAME, ROOT_PACKAGE, generateTuidCalculator(), #[FILE_EXTENSION]);
 		// This is necessary to resolve classes from standard library (e.g. Object, List etc.) 
@@ -22,6 +23,18 @@ final class JavaDomain extends AbstractVitruvDomain {
 	
 	override getBuilderApplicator() {
 		return new VitruviusJavaBuilderApplicator();
+	}
+	
+	override shouldTransitivelyPropagateChanges() {
+		return shouldTransitivelyPropagateChanges;
+	}
+	
+	/**
+	 * Calling this methods enable the per default disabled transitive change propagation.
+	 * Should only be called for test purposes!
+	 */
+	public def enableTransitiveChangePropagation() {
+		shouldTransitivelyPropagateChanges = true
 	}
 	
 }

--- a/bundles/pcm/tools.vitruv.domains.pcm/src/tools/vitruv/domains/pcm/PcmDomain.xtend
+++ b/bundles/pcm/tools.vitruv.domains.pcm/src/tools/vitruv/domains/pcm/PcmDomain.xtend
@@ -10,6 +10,7 @@ import tools.vitruv.domains.emf.builder.VitruviusEmfBuilderApplicator
 
 final class PcmDomain extends AbstractVitruvDomain {
 	private static final String METAMODEL_NAME = "PCM";
+	private boolean shouldTransitivelyPropagateChanges = false;
 	
 	package new() {
 		super(METAMODEL_NAME, ROOT_PACKAGE, 
@@ -26,6 +27,18 @@ final class PcmDomain extends AbstractVitruvDomain {
 	
 	override getBuilderApplicator() {
 		return new VitruviusEmfBuilderApplicator();
+	}
+	
+	override shouldTransitivelyPropagateChanges() {
+		return shouldTransitivelyPropagateChanges;
+	}
+	
+	/**
+	 * Calling this methods enable the per default disabled transitive change propagation.
+	 * Should only be called for test purposes!
+	 */
+	public def enableTransitiveChangePropagation() {
+		shouldTransitivelyPropagateChanges = true
 	}
 	
 }

--- a/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomain.xtend
+++ b/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomain.xtend
@@ -13,6 +13,7 @@ class UmlDomain extends AbstractVitruvDomain {
 	private static final String METAMODEL_NAME = "UML";
 	public static val NAMESPACE_URIS = UMLPackage.eINSTANCE.nsURIsRecursive;
 	public static final String FILE_EXTENSION = UMLResource::FILE_EXTENSION;
+	private boolean shouldTransitivelyPropagateChanges = false;
 
 	package new() {
 		super(METAMODEL_NAME, UMLPackage.eINSTANCE, generateTuidCalculator(), FILE_EXTENSION);
@@ -25,6 +26,18 @@ class UmlDomain extends AbstractVitruvDomain {
 
 	override getBuilderApplicator() {
 		return new VitruviusEmfBuilderApplicator();
+	}
+	
+	override shouldTransitivelyPropagateChanges() {
+		return shouldTransitivelyPropagateChanges;
+	}
+	
+	/**
+	 * Calling this methods enable the per default disabled transitive change propagation.
+	 * Should only be called for test purposes!
+	 */
+	public def enableTransitiveChangePropagation() {
+		shouldTransitivelyPropagateChanges = true
 	}
 	
 }


### PR DESCRIPTION
This PR adds an operation to the Java, PCM and UML domain to manually enable transitive change propagation, which is disabled per default. This can be used for test cases examining transitive change propagation based on Reactions.