### PR TITLE
Register modified UML resource on startup instead of lazy

### DIFF
--- a/bundles/uml/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
+++ b/bundles/uml/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
@@ -4,6 +4,8 @@ Bundle-Name: Vitruvius Domain UML Metamodel
 Bundle-SymbolicName: tools.vitruv.domains.uml;singleton:=true
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: tools.vitruv.domains.uml.Activator
 Require-Bundle: org.junit, 
  org.apache.log4j,
  org.eclipse.uml2.uml;visibility:=reexport,
@@ -15,7 +17,8 @@ Require-Bundle: org.junit,
  org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,
  tools.vitruv.extensions.emf,
- org.eclipse.uml2.uml.resources
+ org.eclipse.uml2.uml.resources,
+ org.eclipse.osgi
 Comment: The above one is necessary because otherwise pathmap resources cannot be loaded
 Export-Package: tools.vitruv.domains.uml,
  tools.vitruv.domains.uml.tuid

--- a/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/Activator.java
+++ b/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/Activator.java
@@ -1,0 +1,47 @@
+package tools.vitruv.domains.uml;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.uml2.uml.internal.resource.UMLResourceWithoutUUIDsFactoryImpl;
+import org.eclipse.uml2.uml.resource.UMLResource;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+public class Activator implements BundleActivator {
+	private static BundleContext context;
+
+    /**
+     * @return The bundle context.
+     */
+    static BundleContext getContext() {
+        return context;
+    }
+
+    /**
+     * Starts the plugin. This is the place where singletons are ensured over various class loaders.
+     *
+     * @param bundleContext
+     *            The bundle context.
+     * @throws Exception
+     *             in case of an error during the initialization.
+     * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
+     */
+    @Override
+    public void start(final BundleContext bundleContext) throws Exception {
+        Activator.context = bundleContext;
+		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put(UMLResource.FILE_EXTENSION, new UMLResourceWithoutUUIDsFactoryImpl());
+    }
+
+    /**
+     * Stops the plugin.
+     *
+     * @param bundleContext
+     *            The bundle context.
+     * @throws Exception
+     *             in case of an error.
+     * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
+     */
+    @Override
+    public void stop(final BundleContext bundleContext) throws Exception {
+        Activator.context = null;
+    }
+}

--- a/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomain.xtend
+++ b/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomain.xtend
@@ -5,8 +5,6 @@ import org.eclipse.uml2.uml.resource.UMLResource
 import tools.vitruv.framework.tuid.TuidCalculatorAndResolver
 import tools.vitruv.domains.uml.tuid.UmlTuidCalculatorAndResolver
 import tools.vitruv.domains.emf.builder.VitruviusEmfBuilderApplicator
-import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.uml2.uml.internal.resource.UMLResourceWithoutUUIDsFactoryImpl
 import tools.vitruv.framework.domains.AbstractTuidAwareVitruvDomain
 
 class UmlDomain extends AbstractTuidAwareVitruvDomain {
@@ -17,7 +15,6 @@ class UmlDomain extends AbstractTuidAwareVitruvDomain {
 
 	package new() {
 		super(METAMODEL_NAME, UMLPackage.eINSTANCE, generateTuidCalculator(), FILE_EXTENSION);
-		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put(UMLResource.FILE_EXTENSION, new UMLResourceWithoutUUIDsFactoryImpl());
 	}
 
 	def protected static TuidCalculatorAndResolver generateTuidCalculator() {


### PR DESCRIPTION
This PR fixes an issue that caused the first test (and potentially also first modification in live models) to fail.
This was due to the reason that the UmlDomain registered our modified UMLResource that does not use the outdated XMI-IDs. Nevertheless, if the `ResourceSet` was already created before calling the domain the first time, the `ResourceSet` used the old resource. To avoid that, this PR adds a bundle activator that already registers the modified domain on startup.