### PR TITLE
Change EMFText dependency to dump due to unavailability of updatesite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,12 @@
 			<layout>p2</layout>
 			<url>http://download.eclipse.org/eclipse/updates/4.7</url>
 		</repository>
+		<!--EMFText repository currently not available
 		<repository>
 			<id>EMFText</id>
 			<layout>p2</layout>
 			<url>http://update.emftext.org/release</url>
-		</repository>
+		</repository>-->
 		<repository>
 			<id>Papyrus</id>
 			<layout>p2</layout>
@@ -65,9 +66,9 @@
 			<url>https://kit-sdq.github.io/updatesite/nightly/commons/</url>
 		</repository>
 		<repository>
-			<id>JaMoPP (P2 Wrapper)</id>
+			<id>EMFText and JaMoPP (P2 Wrapper)</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/nightly/jamopp-p2/</url>
+			<url>https://kit-sdq.github.io/updatesite/nightly/p2-wrapper/</url>
 		</repository>
 		<repository>
 			<id>SDQ Metamodels</id>

--- a/releng/tools.vitruv.domains.updatesite.aggregated/updatesite.aggr
+++ b/releng/tools.vitruv.domains.updatesite.aggregated/updatesite.aggr
@@ -9,15 +9,13 @@
         <features name="de.uka.ipd.sdq.identifier.feature.feature.group" versionRange="2.1.0"/>
         <features name="org.palladiosimulator.pcm.feature.feature.group" versionRange="4.0.1"/>
       </repositories>
-      <repositories location="http://update.emftext.org/release" mirrorArtifacts="false">
-        <features name="org.emftext.commons.antlr3_4_0.feature.group" versionRange="3.4.0"/>
-        <features name="org.emftext.commons.jdt.feature.group" versionRange="1.4.1"/>
-        <features name="org.emftext.commons.layout.feature.group" versionRange="1.4.1"/>
-      </repositories>
-      <repositories location="http://kit-sdq.github.io/updatesite/nightly/jamopp-p2">
+      <repositories location="http://kit-sdq.github.io/updatesite/nightly/p2-wrapper">
         <features name="org.emftext.language.java.feature.group" versionRange="1.4.1"/>
         <features name="org.emftext.language.java.jdt.feature.group" versionRange="1.4.1"/>
         <features name="org.emftext.language.java.ui.feature.group" versionRange="1.4.1"/>
+		<features name="org.emftext.commons.antlr3_4_0.feature.group" versionRange="3.4.0"/>
+        <features name="org.emftext.commons.jdt.feature.group" versionRange="1.4.1"/>
+        <features name="org.emftext.commons.layout.feature.group" versionRange="1.4.1"/>
       </repositories>
       <repositories location="http://kit-sdq.github.io/updatesite/nightly/metamodels">
         <features name="edu.kit.ipd.sdq.metamodels.asem.feature.feature.group" versionRange="0.2.0" categories="//@customCategories[identifier='metamodels']"/>
@@ -58,5 +56,5 @@
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="x86_64"/>
-  <customCategories identifier="metamodels" label="SDQ Metamodels" features="//@validationSets[label='main']/@contributions[label='externals']/@repositories.3/@features.2 //@validationSets[label='main']/@contributions[label='externals']/@repositories.3/@features.1 //@validationSets[label='main']/@contributions[label='externals']/@repositories.3/@features.0"/>
+  <customCategories identifier="metamodels" label="SDQ Metamodels" features="//@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.2 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.1 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.0"/>
 </aggregator:Aggregation>


### PR DESCRIPTION
Since the EMFText udpatesite is unavailable for some days, we deployed a dump to the kit-sdq updatesite, which we refer to now in the domains to make the build work again.